### PR TITLE
Disable "Create" with no onCreateItem

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -287,7 +287,7 @@ export const CUIAutoComplete = <T extends Item>(
                   key={`${item.value}${index}`}
                   {...getItemProps({ item, index })}
                 >
-                  {isCreating ? (
+                  {(isCreating && onCreateItem) ? (
                     <Text>
                       <Box as='span'>Create</Box>{' '}
                       <Box as='span' bg='yellow.300' fontWeight='bold'>


### PR DESCRIPTION
I believe this will prevent the "Create ..." option from appearing when the onCreateItem prop is undefined.

Reference #10 