### PR TITLE
add react-highlight-words in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
 		"prettier": "^2.0.4",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
-		"react-highlight-words": "^0.16.0",
 		"react-scripts": "^3.4.1",
 		"react-test-renderer": "^17.0.1",
 		"rimraf": "^3.0.2",
@@ -89,6 +88,7 @@
 	"dependencies": {
 		"downshift": "^6.0.6",
 		"match-sorter": "^4.2.1",
+    "react-highlight-words": "^0.16.0",
 		"react-use": "^15.3.4"
 	}
 }


### PR DESCRIPTION
**react-highlight-words** is needed otherwise the library doesn't work. (Current NPM version as well as master is broken)

It was added on bdcee1e007eb621b46768247b8bf2a1e7bff88b6 but got (accidentally?) reverted on a5191febcc8268e7d16fb963ab92ff6191c572e4

Please merge this and publish a new version on NPM! 

Fixes #7.

Cheers 