### PR TITLE
Feat: Customizable CreateItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ export default function App() {
 | listItemStyleProps     | Object   |          | Custom style props based on chakra-ui for single list item in dropdown, Example`{{ bg: 'gray.100', pt: '4'}}                                                     |
 | selectedIconProps      | Object   |          | Custom style props based on chakra-ui for the green tick icon in dropdown list, Example `{{ bg: 'gray.100', pt: '4'}}                                            |
 | icon      | Object   |   CheckCircleIcon       | @chakra-ui/icons Icon to be displayed instead of CheckCircleIcon                                            |
+| disableCreateItem      | Object   |          | Disable the "create new"  list Item. Default is `false`                                             |
+| createItemRenderer      | Function   |          | Custom Function that can either return a JSX Element or String, in order to control how the create new item within the Dropdown is rendered. The input value is passed as the first function parameter, Example: ``` (value) => `Create ${value}` ```                                            |
 
 ## Todo
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ export default function App() {
     )
   }
 
+  const customCreateItemRender = (value) => {
+    return (
+      <Text>
+        <Box as='span'>Create</Box>{' '}
+        <Box as='span' bg='red.300' fontWeight='bold'>
+          "{value}"
+        </Box>
+      </Text>
+    )
+  }
+
 
 
   return (
@@ -175,6 +186,7 @@ export default function App() {
             onCreateItem={handleCreateItem}
             items={pickerItems}
             itemRenderer={customRender}
+            createItemRenderer={customCreateItemRender}
             selectedItems={selectedItems}
             onSelectedItemsChange={(changes) =>
               handleSelectedItemsChange(changes.selectedItems)

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ export default function App() {
 | selectedIconProps      | Object   |          | Custom style props based on chakra-ui for the green tick icon in dropdown list, Example `{{ bg: 'gray.100', pt: '4'}}                                            |
 | icon      | Object   |   CheckCircleIcon       | @chakra-ui/icons Icon to be displayed instead of CheckCircleIcon                                            |
 | hideToggleButton      | boolean   |          | Hide the toggle button                                         |
-| disableCreateItem      | Object   |          | Disable the "create new"  list Item. Default is `false`                                             |
+| disableCreateItem      | boolean   |          | Disable the "create new"  list Item. Default is `false`                                             |
 | createItemRenderer      | Function   |          | Custom Function that can either return a JSX Element or String, in order to control how the create new item within the Dropdown is rendered. The input value is passed as the first function parameter, Example: ``` (value) => `Create ${value}` ```                                            |
 
 ## Todo

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,17 @@ function defaultOptionFilterFunc<T>(items: T[], inputValue: string) {
   return matchSorter(items, inputValue, { keys: ['value', 'label'] })
 }
 
+function defaultCreateItemRenderer(value: string) {
+  return (
+    <Text>
+      <Box as='span'>Create</Box>{' '}
+      <Box as='span' bg='yellow.300' fontWeight='bold'>
+        "{value}"
+      </Box>
+    </Text>
+  )
+} 
+
 export const CUIAutoComplete = <T extends Item>(
   props: CUIAutoCompleteProps<T>
 ): React.ReactElement<CUIAutoCompleteProps<T>> => {
@@ -69,14 +80,7 @@ export const CUIAutoComplete = <T extends Item>(
     onCreateItem,
     icon,
     disableCreateItem = false,
-    createItemRenderer = (value) => (
-      <Text>
-        <Box as='span'>Create</Box>{' '}
-        <Box as='span' bg='yellow.300' fontWeight='bold'>
-          "{value}"
-        </Box>
-      </Text>
-    ),
+    createItemRenderer = defaultCreateItemRenderer,
     ...downshiftProps
   } = props
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,9 @@ export interface CUIAutoCompleteProps<T extends Item>
   selectedIconProps?: Omit<IconProps, 'name'> & {
     icon: IconProps['name'] | React.ComponentType
   }
-  icon?: ComponentWithAs<"svg", IconProps>;
+  icon?: ComponentWithAs<"svg", IconProps>
+  createItemRenderer?: (value: string) => string | JSX.Element
+  disableCreateItem?: boolean
 }
 
 function defaultOptionFilterFunc<T>(items: T[], inputValue: string) {
@@ -66,6 +68,15 @@ export const CUIAutoComplete = <T extends Item>(
     listItemStyleProps,
     onCreateItem,
     icon,
+    disableCreateItem = false,
+    createItemRenderer = (value) => (
+      <Text>
+        <Box as='span'>Create</Box>{' '}
+        <Box as='span' bg='yellow.300' fontWeight='bold'>
+          "{value}"
+        </Box>
+      </Text>
+    ),
     ...downshiftProps
   } = props
 
@@ -172,13 +183,13 @@ export const CUIAutoComplete = <T extends Item>(
   })
 
   React.useEffect(() => {
-    if (inputItems.length === 0) {
+    if (inputItems.length === 0 && !disableCreateItem) {
       setIsCreating(true)
       // @ts-ignore
       setInputItems([{ label: `${inputValue}`, value: inputValue }])
       setHighlightedIndex(0)
     }
-  }, [inputItems, setIsCreating, setHighlightedIndex, inputValue])
+  }, [inputItems, setIsCreating, setHighlightedIndex, inputValue, disableCreateItem])
 
   useDeepCompareEffect(() => {
     setInputItems(items)
@@ -262,12 +273,7 @@ export const CUIAutoComplete = <T extends Item>(
                 {...getItemProps({ item, index })}
               >
                 {isCreating ? (
-                  <Text>
-                    <Box as='span'>Create</Box>{' '}
-                    <Box as='span' bg='yellow.300' fontWeight='bold'>
-                      "{item.label}"
-                    </Box>
-                  </Text>
+                  createItemRenderer(item.label)
                 ) : (
                     <Box display='inline-flex' alignItems='center'>
                       {selectedItemValues.includes(item.value) && (


### PR DESCRIPTION
### Description
Added boolean prop: `disableCreateItem` that hide the **create Item** row, default value is: `false`.
Added function prop: `createItemRenderer` that can render a custom string/JSX Element, by default it render a default item (the one that is rendered right now).

### Motivation and Context
We have a situation where we use the autocomplete as a filter input, so item creation must be disabled.
With `createItemRenderer` we tried to resolve the i18n problem.

### How Has This Been Tested?
I didn't write any test.
Tested on Google Chrome browser.

### Related Issues
This closes #29 and closes #35.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

